### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -2,6 +2,10 @@ name: Greetings
 
 on: [pull_request, issues]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   greeting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/notti-io/dependabotdocs/security/code-scanning/2](https://github.com/notti-io/dependabotdocs/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow interacts with issues and pull requests, it requires `issues: write` and `pull-requests: write` permissions. These permissions should be added at the workflow level to apply to all jobs unless overridden. This ensures the workflow adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
