### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/notti-io/dependabotdocs/security/code-scanning/1](https://github.com/notti-io/dependabotdocs/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since this is a basic CI pipeline, the minimal permissions required are `contents: read`. This ensures the workflow can access repository contents without granting unnecessary write permissions. The `permissions` block should be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
